### PR TITLE
Microsoft.Net.Http.Client -> System.Net.Http

### DIFF
--- a/src/Microsoft.AspNet.Proxy/ProxyMiddleware.cs
+++ b/src/Microsoft.AspNet.Proxy/ProxyMiddleware.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNet.Proxy
 #if DNX451
             _httpClient = new HttpClient(_options.BackChannelMessageHandler?? new HttpClientHandler());
 #else
-            _httpClient = new HttpClient(_options.BackChannelMessageHandler?? new Net.Http.Client.ManagedHandler());
+            _httpClient = new HttpClient(_options.BackChannelMessageHandler?? new HttpClientHandler());
 #endif
 
         }

--- a/src/Microsoft.AspNet.Proxy/ProxyMiddleware.cs
+++ b/src/Microsoft.AspNet.Proxy/ProxyMiddleware.cs
@@ -47,12 +47,7 @@ namespace Microsoft.AspNet.Proxy
 
             _options = options;
 
-#if DNX451
-            _httpClient = new HttpClient(_options.BackChannelMessageHandler?? new HttpClientHandler());
-#else
-            _httpClient = new HttpClient(_options.BackChannelMessageHandler?? new HttpClientHandler());
-#endif
-
+            _httpClient = new HttpClient(_options.BackChannelMessageHandler ?? new HttpClientHandler());
         }
 
         public async Task Invoke(HttpContext context)

--- a/src/Microsoft.AspNet.Proxy/project.json
+++ b/src/Microsoft.AspNet.Proxy/project.json
@@ -18,9 +18,9 @@
       "dependencies": {
         "System.Collections": "4.0.10-*",
         "System.Linq": "4.0.0-*",
+        "System.Net.Http": "4.0.1-*",
         "System.Threading": "4.0.10-*",
-        "Microsoft.CSharp": "4.0.0-*",
-        "Microsoft.Net.Http.Client": "1.0.0-*"
+        "Microsoft.CSharp": "4.0.0-*"
       }
     }
   }

--- a/test/Microsoft.AspNet.Proxy.Test/project.json
+++ b/test/Microsoft.AspNet.Proxy.Test/project.json
@@ -1,23 +1,25 @@
 {
-  "version": "1.0.0-*",
-  "description": "Microsoft.AspNet.Proxy.Test Class Library",
-  "dependencies": {
-    "Microsoft.Net.Http.Client": "1.0.0-*",
-    "Microsoft.AspNet.Proxy": "1.0.0-*",
-    "Microsoft.AspNet.TestHost": "1.0.0-*",
-    "xunit.runner.aspnet": "2.0.0-aspnet-*"
-  },
-  "commands": {
-    "test": "xunit.runner.aspnet"
-  },
-  "frameworks": {
-    "dnx451": { },
-    "dnxcore50": {
-      "dependencies": {
-        "System.Collections": "4.0.10-*",
-        "System.Linq": "4.0.0-*",
-        "Microsoft.CSharp": "4.0.0-*"
-      }
+    "version": "1.0.0-*",
+    "description": "Microsoft.AspNet.Proxy.Test Class Library",
+    "dependencies": {
+        "Microsoft.AspNet.Proxy": "1.0.0-*",
+        "Microsoft.AspNet.TestHost": "1.0.0-*",
+        "xunit.runner.aspnet": "2.0.0-aspnet-*"
+    },
+    "commands": {
+        "test": "xunit.runner.aspnet"
+    },
+    "frameworks": {
+        "dnx451": {
+            "frameworkAssemblies": { "System.Net.Http": "" }
+        },
+        "dnxcore50": {
+            "dependencies": {
+                "System.Collections": "4.0.10-*",
+                "System.Linq": "4.0.0-*",
+                "System.Net.Http": "4.0.1-*",
+                "Microsoft.CSharp": "4.0.0-*"
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
While CoreCLR has a functioning ```HttpClient```, the ```Microsoft.Net.Http.Client``` should be removed. This is based on issue #6 