### PR TITLE
multi domain to multi proxy host

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetcirelease/api/v3/index.json" />
+    <clear />
+    <add key="AspNetVNext" value="https://www.myget.org/f/aspnetmaster/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/global.json
+++ b/global.json
@@ -1,3 +1,9 @@
-﻿{
-  "projects": [ "src", "test" ]
+{
+  "projects": [
+    "src",
+    "test"
+  ],
+  "sdk": {
+    "version": "1.0.0-rc1-final"
+  }
 }

--- a/samples/Microsoft.AspNet.Proxy.Samples/project.json
+++ b/samples/Microsoft.AspNet.Proxy.Samples/project.json
@@ -1,22 +1,18 @@
-﻿{
+{
   "webroot": "wwwroot",
   "version": "1.0.0-*",
-
   "dependencies": {
     "Microsoft.AspNet.Server.IIS": "1.0.0-*",
-    "Microsoft.AspNet.Server.WebListener": "1.0.0-*",
-    "Microsoft.AspNet.Proxy": "1.0.0-*"
+    "Microsoft.AspNet.Server.WebListener": "1.0.0-rc1-final",
+    "Microsoft.AspNet.Proxy": "1.0.0-rc1-final"
   },
-
   "commands": {
     "web": "Microsoft.AspNet.Server.WebListener --server.urls=http://localhost:5000"
   },
-
   "frameworks": {
-    "dnx451": { },
-    "dnxcore50": { }
+    "dnx451": {},
+    "dnxcore50": {}
   },
-
   "publishExclude": [
     "node_modules",
     "bower_components",

--- a/src/Microsoft.AspNet.Proxy/IProxyOptions.cs
+++ b/src/Microsoft.AspNet.Proxy/IProxyOptions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Proxy
+{
+    interface IProxyOptions
+    {
+        string Scheme { get; set; }
+        string Host { get; set; }
+        string Port { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Proxy/MultiProxyOptions.cs
+++ b/src/Microsoft.AspNet.Proxy/MultiProxyOptions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Proxy
+{
+    /// <summary>
+    /// Options to configure multi domain to multi proxy host
+    /// </summary>
+    public class MultiProxyDictionaryOptions : Dictionary<string, MultiProxyOptionsValue>
+    {
+        public MultiProxyDictionaryOptions(ProxyOptions defaultOptions)
+        {
+            DefaultOptions = defaultOptions;
+        }
+        public HttpMessageHandler BackChannelMessageHandler { get; set; }
+
+        public ProxyOptions DefaultOptions { get; set; }
+        
+    }
+
+
+}

--- a/src/Microsoft.AspNet.Proxy/MultiProxyOptionsValue.cs
+++ b/src/Microsoft.AspNet.Proxy/MultiProxyOptionsValue.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Proxy
+{
+    public class MultiProxyOptionsValue : IProxyOptions
+    {
+        public string Scheme { get; set; }
+        public string Host { get; set; }
+        public string Port { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Proxy/ProxyExtension.cs
+++ b/src/Microsoft.AspNet.Proxy/ProxyExtension.cs
@@ -17,5 +17,16 @@ namespace Microsoft.AspNet.Builder
         {
             return builder.UseMiddleware<ProxyMiddleware>(options);
         }
+
+        /// <summary>
+        /// Sends request to remote server as specified in options array
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="options">Options to configure multi domain to multi proxy host</param>
+        /// <returns></returns>
+        public static IApplicationBuilder RunProxy(this IApplicationBuilder builder, MultiProxyDictionaryOptions options)
+        {
+            return builder.UseMiddleware<ProxyMiddleware>(options);
+        }
     }
 }

--- a/src/Microsoft.AspNet.Proxy/ProxyOptions.cs
+++ b/src/Microsoft.AspNet.Proxy/ProxyOptions.cs
@@ -8,11 +8,12 @@ namespace Microsoft.AspNet.Proxy
     /// <summary>
     /// Options to configure host, scheme, and port settings
     /// </summary>
-    public class ProxyOptions
+    public class ProxyOptions: IProxyOptions
     {
         public string Scheme { get; set; }
         public string Host { get; set; }
         public string Port { get; set; }
         public HttpMessageHandler BackChannelMessageHandler { get; set; }
     }
+
 }

--- a/src/Microsoft.AspNet.Proxy/project.json
+++ b/src/Microsoft.AspNet.Proxy/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-*",
+  "version": "1.0.0-rc1-final",
   "compilationOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk"
@@ -10,7 +10,7 @@
     "url": "git://github.com/aspnet/proxy"
   },
   "dependencies": {
-    "Microsoft.AspNet.Http.Abstractions": "1.0.0-*"
+    "Microsoft.AspNet.Http.Abstractions": "1.0.0-rc1-final"
   },
   "frameworks": {
     "net451": {
@@ -20,7 +20,7 @@
     },
     "dotnet5.4": {
       "dependencies": {
-        "System.Net.Http": "4.0.1-*"
+        "System.Net.Http": "4.0.1-beta-23516"
       }
     }
   }

--- a/test/Microsoft.AspNet.Proxy.Test/project.json
+++ b/test/Microsoft.AspNet.Proxy.Test/project.json
@@ -1,19 +1,18 @@
 {
-    "version": "1.0.0-*",
-    "description": "Microsoft.AspNet.Proxy.Test Class Library",
-    "dependencies": {
-        "Microsoft.AspNet.Proxy": "1.0.0-*",
-        "Microsoft.AspNet.TestHost": "1.0.0-*",
-        "xunit.runner.aspnet": "2.0.0-aspnet-*"
-    },
-    "commands": {
-        "test": "xunit.runner.aspnet"
-    },
-    "frameworks": {
-        "dnx451": { },
-        "dnxcore50": {
-            "dependencies": {
-            }
-        }
+  "version": "1.0.0-*",
+  "description": "Microsoft.AspNet.Proxy.Test Class Library",
+  "dependencies": {
+    "Microsoft.AspNet.Proxy": "1.0.0-rc1-final",
+    "Microsoft.AspNet.TestHost": "1.0.0-rc1-final",
+    "xunit.runner.aspnet": "2.0.0-aspnet-rc1-final"
+  },
+  "commands": {
+    "test": "xunit.runner.aspnet"
+  },
+  "frameworks": {
+    "dnx451": {},
+    "dnxcore50": {
+      "dependencies": {}
     }
+  }
 }


### PR DESCRIPTION
[suggest] multi domain to multi proxy host



            var dictOptions = new MultiProxyDictionaryOptions(defaultOptions = new ProxyOptions()
            {
                Scheme = scheme,
                Host = host,
                Port = port
            });
            dictOptions.Add("microsoft.proxy.com", new MultiProxyOptionsValue {Host = "www.microsoft.com"});
            dictOptions.Add("aspnet.proxy.com", new MultiProxyOptionsValue { Host = "www.asp.net" });
            dictOptions.Add("github.proxy.com", new MultiProxyOptionsValue { Host = "www.github.com" });

            app.RunProxy(dictOptions);