### PR TITLE
Added support for WebSockets

### DIFF
--- a/Proxy.sln
+++ b/Proxy.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26127.0
+VisualStudioVersion = 15.0.26206.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{339381AB-344C-47CD-BA9D-30310AEB8DFF}"
 EndProject
@@ -21,10 +20,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B2AF7BAB-E974-42A8-93A2-6CFE10BD8919}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B2AF7BAB-E974-42A8-93A2-6CFE10BD8919}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B2AF7BAB-E974-42A8-93A2-6CFE10BD8919}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B2AF7BAB-E974-42A8-93A2-6CFE10BD8919}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2AF7BAB-E974-42A8-93A2-6CFE10BD8919}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{B2AF7BAB-E974-42A8-93A2-6CFE10BD8919}.Debug|Any CPU.Build.0 = Debug|x64
+		{B2AF7BAB-E974-42A8-93A2-6CFE10BD8919}.Release|Any CPU.ActiveCfg = Release|x64
+		{B2AF7BAB-E974-42A8-93A2-6CFE10BD8919}.Release|Any CPU.Build.0 = Release|x64
 		{4DAA0A9D-056E-4429-8C04-83715A93B56E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4DAA0A9D-056E-4429-8C04-83715A93B56E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4DAA0A9D-056E-4429-8C04-83715A93B56E}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/samples/Microsoft.AspNetCore.Proxy.Samples/Microsoft.AspNetCore.Proxy.Samples.csproj
+++ b/samples/Microsoft.AspNetCore.Proxy.Samples/Microsoft.AspNetCore.Proxy.Samples.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp1.1</TargetFrameworks>
     <!-- TODO remove when https://github.com/dotnet/sdk/issues/396 is resolved -->
     <RuntimeIdentifier Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">win7-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>

--- a/samples/Microsoft.AspNetCore.Proxy.Samples/Startup.cs
+++ b/samples/Microsoft.AspNetCore.Proxy.Samples/Startup.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Proxy
             const string scheme = "https";
             const string host = "example.com";
             const string port = "443";
-            app.RunProxy(new ProxyOptions
+            app.UseWebSockets().RunProxy(new ProxyOptions
             {
                 Scheme = scheme,
                 Host = host,

--- a/src/Microsoft.AspNetCore.Proxy/Microsoft.AspNetCore.Proxy.csproj
+++ b/src/Microsoft.AspNetCore.Proxy/Microsoft.AspNetCore.Proxy.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Proxy Library</Description>
-    <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
@@ -12,7 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.2.0-*" />
+    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="1.0.0-*" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="1.2.0-*" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.4.0-*" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Proxy/Microsoft.AspNetCore.Proxy.csproj
+++ b/src/Microsoft.AspNetCore.Proxy/Microsoft.AspNetCore.Proxy.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="1.0.0-*" />
+    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="1.1.0-*" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="1.2.0-*" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.4.0-*" />
+    <PackageReference Include="System.Net.Http" Version="4.4.0-*" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Proxy/ProxyMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Proxy/ProxyMiddleware.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Proxy
             {
                 foreach (var kv in context.Request.Headers)
                 {
-                    if (!NotForwardedWebSocketHeaders.Contains(kv.Key))
+                    if (!NotForwardedWebSocketHeaders.Contains(kv.Key, StringComparer.OrdinalIgnoreCase))
                     {
                         client.Options.SetRequestHeader(kv.Key, kv.Value);
                     }
@@ -122,7 +122,7 @@ namespace Microsoft.AspNetCore.Proxy
                 var res = await source.ReceiveAsync(new ArraySegment<byte>(buffer), ct);
                 if (res.MessageType == WebSocketMessageType.Close)
                 {
-                    await dest.CloseAsync(source.CloseStatus.Value, source.CloseStatusDescription, ct);
+                    await dest.CloseOutputAsync(source.CloseStatus.Value, source.CloseStatusDescription, ct);
                     return;
                 }
                 else

--- a/src/Microsoft.AspNetCore.Proxy/ProxyMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Proxy/ProxyMiddleware.cs
@@ -106,12 +106,6 @@ namespace Microsoft.AspNetCore.Proxy
 
         private void HandleWebSocketConnectError(HttpContext context, WebSocketException ex)
         {
-            //WebException is not available in netstandard13
-            //TODO: Uncomment and forward response when implemented
-            //var res = (ex.InnerException as WebException)?.Response;
-            //if (res != null)
-            //{
-            //}
             context.Response.StatusCode = 400;
         }
 

--- a/src/Microsoft.AspNetCore.Proxy/ProxyMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Proxy/ProxyMiddleware.cs
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.Proxy
                 }
                 catch (OperationCanceledException)
                 {
-                    await destination.CloseOutputAsync(WebSocketCloseStatus.InternalServerError, null, cancellationToken);
+                    await destination.CloseOutputAsync(WebSocketCloseStatus.EndpointUnavailable, null, cancellationToken);
                     return;
                 }
                 if (result.MessageType == WebSocketMessageType.Close)

--- a/src/Microsoft.AspNetCore.Proxy/ProxyMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Proxy/ProxyMiddleware.cs
@@ -124,10 +124,8 @@ namespace Microsoft.AspNetCore.Proxy
                     await destination.CloseOutputAsync(source.CloseStatus.Value, source.CloseStatusDescription, cancellationToken);
                     return;
                 }
-                else
-                {
-                    await destination.SendAsync(new ArraySegment<byte>(buffer, 0, result.Count), result.MessageType, result.EndOfMessage, cancellationToken);
-                }
+
+                await destination.SendAsync(new ArraySegment<byte>(buffer, 0, result.Count), result.MessageType, result.EndOfMessage, cancellationToken);
             }
         }
 

--- a/src/Microsoft.AspNetCore.Proxy/ProxyMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Proxy/ProxyMiddleware.cs
@@ -1,15 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Options;
 using System;
 using System.Linq;
 using System.Net.Http;
 using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Proxy
 {

--- a/src/Microsoft.AspNetCore.Proxy/ProxyMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Proxy/ProxyMiddleware.cs
@@ -96,11 +96,6 @@ namespace Microsoft.AspNetCore.Proxy
                     context.Response.StatusCode = 400;
                     return;
                 }
-                catch (OperationCanceledException)
-                {
-                    context.Response.StatusCode = 500;
-                    return;
-                }
 
                 using (var server = await context.WebSockets.AcceptWebSocketAsync(client.SubProtocol))
                 {

--- a/src/Microsoft.AspNetCore.Proxy/ProxyOptions.cs
+++ b/src/Microsoft.AspNetCore.Proxy/ProxyOptions.cs
@@ -11,10 +11,17 @@ namespace Microsoft.AspNetCore.Builder
     /// </summary>
     public class ProxyOptions
     {
+        private int? _webSocketBufferSize;
+
         public string Scheme { get; set; }
         public string Host { get; set; }
         public string Port { get; set; }
         public HttpMessageHandler BackChannelMessageHandler { get; set; }
         public TimeSpan? WebSocketKeepAliveInterval { get; set; }
+        public int? WebSocketBufferSize
+        {
+            get => _webSocketBufferSize;
+            set => _webSocketBufferSize = value.HasValue && value.Value <= 0 ? throw new ArgumentOutOfRangeException(nameof(value)) : value;
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Proxy/ProxyOptions.cs
+++ b/src/Microsoft.AspNetCore.Proxy/ProxyOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Net.Http;
 
 namespace Microsoft.AspNetCore.Builder
@@ -14,5 +15,6 @@ namespace Microsoft.AspNetCore.Builder
         public string Host { get; set; }
         public string Port { get; set; }
         public HttpMessageHandler BackChannelMessageHandler { get; set; }
+        public TimeSpan? WebSocketKeepAliveInterval { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Proxy/ProxyOptions.cs
+++ b/src/Microsoft.AspNetCore.Proxy/ProxyOptions.cs
@@ -21,7 +21,14 @@ namespace Microsoft.AspNetCore.Builder
         public int? WebSocketBufferSize
         {
             get => _webSocketBufferSize;
-            set => _webSocketBufferSize = value.HasValue && value.Value <= 0 ? throw new ArgumentOutOfRangeException(nameof(value)) : value;
+            set 
+            {
+                if (value.HasValue && value.Value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+                _webSocketBufferSize = value;
+            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Proxy.Test/Microsoft.AspNetCore.Proxy.Test.csproj
+++ b/test/Microsoft.AspNetCore.Proxy.Test/Microsoft.AspNetCore.Proxy.Test.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 

--- a/test/Microsoft.AspNetCore.Proxy.Test/Microsoft.AspNetCore.Proxy.Test.csproj
+++ b/test/Microsoft.AspNetCore.Proxy.Test/Microsoft.AspNetCore.Proxy.Test.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Proxy\Microsoft.AspNetCore.Proxy.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.2.0-*" />
+    <PackageReference Include="Microsoft.AspNetCore.Testing" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
     <PackageReference Include="xunit" Version="2.2.0-*" />

--- a/test/Microsoft.AspNetCore.Proxy.Test/Microsoft.AspNetCore.Proxy.Test.csproj
+++ b/test/Microsoft.AspNetCore.Proxy.Test/Microsoft.AspNetCore.Proxy.Test.csproj
@@ -11,10 +11,15 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp1.1'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Proxy\Microsoft.AspNetCore.Proxy.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.2.0-preview1-23599" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.2.0-*" />
+    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
     <PackageReference Include="xunit" Version="2.2.0-*" />

--- a/test/Microsoft.AspNetCore.Proxy.Test/Microsoft.AspNetCore.Proxy.Test.csproj
+++ b/test/Microsoft.AspNetCore.Proxy.Test/Microsoft.AspNetCore.Proxy.Test.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Proxy\Microsoft.AspNetCore.Proxy.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.2.0-preview1-23599" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />

--- a/test/Microsoft.AspNetCore.Proxy.Test/Microsoft.AspNetCore.Proxy.Test.csproj
+++ b/test/Microsoft.AspNetCore.Proxy.Test/Microsoft.AspNetCore.Proxy.Test.csproj
@@ -19,7 +19,6 @@
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Proxy\Microsoft.AspNetCore.Proxy.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
     <PackageReference Include="xunit" Version="2.2.0-*" />

--- a/test/Microsoft.AspNetCore.Proxy.Test/Microsoft.AspNetCore.Proxy.Test.csproj
+++ b/test/Microsoft.AspNetCore.Proxy.Test/Microsoft.AspNetCore.Proxy.Test.csproj
@@ -6,6 +6,11 @@
     <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- TODO remove when https://github.com/Microsoft/vstest/issues/428 is resolved -->
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Proxy\Microsoft.AspNetCore.Proxy.csproj" />

--- a/test/Microsoft.AspNetCore.Proxy.Test/WebSocketsTest.cs
+++ b/test/Microsoft.AspNetCore.Proxy.Test/WebSocketsTest.cs
@@ -1,13 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.TestHost;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Proxy.Test
@@ -24,50 +24,58 @@ namespace Microsoft.AspNetCore.Proxy.Test
                 Assert.Equal(WebSocketMessageType.Text, res.MessageType);
                 received += res.Count;
                 if (res.EndOfMessage)
+                {
                     return Encoding.UTF8.GetString(recvBuff, 0, received);
+                }
                 Assert.InRange(received, 0, maxLen);
             }
         }
 
         [Fact]
-        public async Task SmokeTest1()
+        public async Task ProxyWebSocketsSmokeTest()
         {
-            var server = new WebHostBuilder()
+            const string supportedSubProtocol = "myproto2";
+            const string otherSubProtocol = "myproto1";
+            const string message1Content = "TEST MESSAGE 1";
+            const string message2Content = "TEST MSG 2";
+            const string message3Content = "TEST MESSAGE 3";
+            const string closeStatusDescription = "My Status1";
+
+            using (var server = new WebHostBuilder()
                 .UseKestrel()
                 .Configure(app => app.UseWebSockets().Run(async ctx =>
                 {
-                    var socket = await ctx.WebSockets.AcceptWebSocketAsync("myproto2");
+                    var socket = await ctx.WebSockets.AcceptWebSocketAsync(supportedSubProtocol);
                     var message1 = await ReceiveTextMessage(socket);
                     var message2 = await ReceiveTextMessage(socket);
-                    Assert.Equal("TEST MESSAGE 1", message1);
-                    Assert.Equal("TEST MSG 2", message2);
-                    await socket.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes("TEST MESSAGE 3")), WebSocketMessageType.Text, true, CancellationToken.None);
-                    await socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "My Status1", CancellationToken.None);
-                })).Start("http://localhost:4001");
-
-            var proxy = new WebHostBuilder()
+                    Assert.Equal(message1Content, message1);
+                    Assert.Equal(message2Content, message2);
+                    await socket.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes(message3Content)), WebSocketMessageType.Text, true, CancellationToken.None);
+                    await socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, closeStatusDescription, CancellationToken.None);
+                })).Start("http://localhost:4001"))
+            using (var proxy = new WebHostBuilder()
                 .UseKestrel()
-                .Configure(app => app.UseWebSockets().RunProxy(new ProxyOptions { Scheme = "http", Host = "localhost", Port = "4001" })).Start("http://localhost:4002");
-
+                .Configure(app => app.UseWebSockets().RunProxy(new ProxyOptions { Scheme = "http", Host = "localhost", Port = "4001" }))
+                .Start("http://localhost:4002"))
             using (var client = new ClientWebSocket())
             {
-                client.Options.AddSubProtocol("myproto1");
-                client.Options.AddSubProtocol("myproto2");
+                client.Options.AddSubProtocol(otherSubProtocol);
+                client.Options.AddSubProtocol(supportedSubProtocol);
                 await client.ConnectAsync(new Uri("ws://localhost:4002"), CancellationToken.None);
-                Assert.Equal("myproto2", client.SubProtocol);
-                await client.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes("TEST MESSAGE 1")), WebSocketMessageType.Text, true, CancellationToken.None);
-                await client.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes("TEST MSG 2")), WebSocketMessageType.Text, true, CancellationToken.None);
+                Assert.Equal(supportedSubProtocol, client.SubProtocol);
+
+                await client.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes(message1Content)), WebSocketMessageType.Text, true, CancellationToken.None);
+                await client.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes(message2Content)), WebSocketMessageType.Text, true, CancellationToken.None);
                 var message3 = await ReceiveTextMessage(client);
-                Assert.Equal("TEST MESSAGE 3", message3);
+                Assert.Equal(message3Content, message3);
+
                 var recv = await client.ReceiveAsync(new ArraySegment<byte>(new byte[4096]), CancellationToken.None);
                 Assert.Equal(WebSocketMessageType.Close, recv.MessageType);
                 Assert.Equal(WebSocketCloseStatus.NormalClosure, recv.CloseStatus);
-                Assert.Equal("My Status1", recv.CloseStatusDescription);
-                await client.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "My Status2", CancellationToken.None);
-            }
+                Assert.Equal(closeStatusDescription, recv.CloseStatusDescription);
 
-            server.Dispose();
-            proxy.Dispose();
+                await client.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, closeStatusDescription, CancellationToken.None);
+            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Proxy.Test/WebSocketsTest.cs
+++ b/test/Microsoft.AspNetCore.Proxy.Test/WebSocketsTest.cs
@@ -16,16 +16,16 @@ namespace Microsoft.AspNetCore.Proxy.Test
     {
         private static async Task<string> ReceiveTextMessage(WebSocket socket, int maxLen = 4096)
         {
-            var recvBuff = new byte[maxLen];
+            var buffer = new byte[maxLen];
             var received = 0;
             while (true)
             {
-                var res = await socket.ReceiveAsync(new ArraySegment<byte>(recvBuff, received, maxLen - received), CancellationToken.None);
-                Assert.Equal(WebSocketMessageType.Text, res.MessageType);
-                received += res.Count;
-                if (res.EndOfMessage)
+                var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer, received, maxLen - received), CancellationToken.None);
+                Assert.Equal(WebSocketMessageType.Text, result.MessageType);
+                received += result.Count;
+                if (result.EndOfMessage)
                 {
-                    return Encoding.UTF8.GetString(recvBuff, 0, received);
+                    return Encoding.UTF8.GetString(buffer, 0, received);
                 }
                 Assert.InRange(received, 0, maxLen);
             }
@@ -69,10 +69,10 @@ namespace Microsoft.AspNetCore.Proxy.Test
                 var message3 = await ReceiveTextMessage(client);
                 Assert.Equal(message3Content, message3);
 
-                var recv = await client.ReceiveAsync(new ArraySegment<byte>(new byte[4096]), CancellationToken.None);
-                Assert.Equal(WebSocketMessageType.Close, recv.MessageType);
-                Assert.Equal(WebSocketCloseStatus.NormalClosure, recv.CloseStatus);
-                Assert.Equal(closeStatusDescription, recv.CloseStatusDescription);
+                var result = await client.ReceiveAsync(new ArraySegment<byte>(new byte[4096]), CancellationToken.None);
+                Assert.Equal(WebSocketMessageType.Close, result.MessageType);
+                Assert.Equal(WebSocketCloseStatus.NormalClosure, result.CloseStatus);
+                Assert.Equal(closeStatusDescription, result.CloseStatusDescription);
 
                 await client.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, closeStatusDescription, CancellationToken.None);
             }

--- a/test/Microsoft.AspNetCore.Proxy.Test/WebSocketsTest.cs
+++ b/test/Microsoft.AspNetCore.Proxy.Test/WebSocketsTest.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Proxy.Test
+{
+    public class WebSocketsTest
+    {
+        private static async Task<string> ReceiveTextMessage(WebSocket socket, int maxLen = 4096)
+        {
+            var recvBuff = new byte[maxLen];
+            var received = 0;
+            while (true)
+            {
+                var res = await socket.ReceiveAsync(new ArraySegment<byte>(recvBuff, received, maxLen - received), CancellationToken.None);
+                Assert.Equal(WebSocketMessageType.Text, res.MessageType);
+                received += res.Count;
+                if (res.EndOfMessage)
+                    return Encoding.UTF8.GetString(recvBuff, 0, received);
+                Assert.InRange(received, 0, maxLen);
+            }
+        }
+
+        [Fact]
+        public async Task SmokeTest1()
+        {
+            var server = new WebHostBuilder()
+                .UseKestrel()
+                .Configure(app => app.UseWebSockets().Run(async ctx =>
+                {
+                    var socket = await ctx.WebSockets.AcceptWebSocketAsync("myproto2");
+                    var message1 = await ReceiveTextMessage(socket);
+                    var message2 = await ReceiveTextMessage(socket);
+                    Assert.Equal("TEST MESSAGE 1", message1);
+                    Assert.Equal("TEST MSG 2", message2);
+                    await socket.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes("TEST MESSAGE 3")), WebSocketMessageType.Text, true, CancellationToken.None);
+                    await socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "My Status1", CancellationToken.None);
+                })).Start("http://localhost:4001");
+
+            var proxy = new WebHostBuilder()
+                .UseKestrel()
+                .Configure(app => app.UseWebSockets().RunProxy(new ProxyOptions { Scheme = "http", Host = "localhost", Port = "4001" })).Start("http://localhost:4002");
+
+            using (var client = new ClientWebSocket())
+            {
+                client.Options.AddSubProtocol("myproto1");
+                client.Options.AddSubProtocol("myproto2");
+                await client.ConnectAsync(new Uri("ws://localhost:4002"), CancellationToken.None);
+                Assert.Equal("myproto2", client.SubProtocol);
+                await client.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes("TEST MESSAGE 1")), WebSocketMessageType.Text, true, CancellationToken.None);
+                await client.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes("TEST MSG 2")), WebSocketMessageType.Text, true, CancellationToken.None);
+                var message3 = await ReceiveTextMessage(client);
+                Assert.Equal("TEST MESSAGE 3", message3);
+                var recv = await client.ReceiveAsync(new ArraySegment<byte>(new byte[4096]), CancellationToken.None);
+                Assert.Equal(WebSocketMessageType.Close, recv.MessageType);
+                Assert.Equal(WebSocketCloseStatus.NormalClosure, recv.CloseStatus);
+                Assert.Equal("My Status1", recv.CloseStatusDescription);
+                await client.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "My Status2", CancellationToken.None);
+            }
+
+            server.Dispose();
+            proxy.Dispose();
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Proxy.Test/WebSocketsTest.cs
+++ b/test/Microsoft.AspNetCore.Proxy.Test/WebSocketsTest.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Proxy.Test
@@ -32,6 +33,7 @@ namespace Microsoft.AspNetCore.Proxy.Test
         }
 
         [Fact]
+        [OSSkipCondition(OperatingSystems.Windows, WindowsVersions.Win7, WindowsVersions.Win2008R2, SkipReason = "No WebSockets Client for this platform")]
         public async Task ProxyWebSocketsSmokeTest()
         {
             const string supportedSubProtocol = "myproto2";


### PR DESCRIPTION
Added support for WebSockets
 - Bumped .NET Framework version to 4.6 (required by System.Net.WebSockets.Client)
 - Updated sample project to be HttpUpgradeFeature-compatible

Addresses #38 

Known issues:
- Connection closing handshake crashes when using IIS Express (It works correctly with standalone Kestrel and WebListener)
- Lacking tests - it would be good idea to test it using Autobahn Testsuite