### PR TITLE
Added PrepareWebSocketClient option

### DIFF
--- a/src/Microsoft.AspNetCore.Proxy/ProxyAdvancedExtensions.cs
+++ b/src/Microsoft.AspNetCore.Proxy/ProxyAdvancedExtensions.cs
@@ -101,6 +101,12 @@ namespace Microsoft.AspNetCore.Proxy
                     client.Options.KeepAliveInterval = proxyService.Options.WebSocketKeepAliveInterval.Value;
                 }
 
+                var prepareWebSocketClient = proxyService.Options.PrepareWebSocketClient;
+                if (prepareWebSocketClient != null)
+                {
+                    await prepareWebSocketClient(context.Request, client);
+                }
+
                 try
                 {
                     await client.ConnectAsync(destinationUri, context.RequestAborted);

--- a/src/Microsoft.AspNetCore.Proxy/SharedProxyOptions.cs
+++ b/src/Microsoft.AspNetCore.Proxy/SharedProxyOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using System.Net.WebSockets;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
@@ -24,6 +25,11 @@ namespace Microsoft.AspNetCore.Proxy
         /// Allows to modify HttpRequestMessage before it is sent to the Message Handler.
         /// </summary>
         public Func<HttpRequest, HttpRequestMessage, Task> PrepareRequest { get; set; }
+
+        /// <summary>
+        /// Allows to modify ClientWebSocket before the connection is opened.
+        /// </summary>
+        public Func<HttpRequest, ClientWebSocket, Task> PrepareWebSocketClient { get; set; }
 
         /// <summary>
         /// Keep-alive interval for proxied Web Socket connections.


### PR DESCRIPTION
There was already a PrepareRequest for HttpRequests and with this we have the same for websockets. This PR replaces #75 as the rest of #75 is already possible in a better way, as described by @mkosieradzki .