### PR TITLE
Use HttpClientFactory

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -10,6 +10,7 @@
     <MicrosoftAspNetCoreTestingPackageVersion>2.2.0-preview1-34530</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftAspNetCoreWebSocketsPackageVersion>2.2.0-preview1-34530</MicrosoftAspNetCoreWebSocketsPackageVersion>
     <MicrosoftExtensionsOptionsPackageVersion>2.2.0-preview1-34530</MicrosoftExtensionsOptionsPackageVersion>
+    <MicrosoftExtensionsHttpPackageVersion>2.2.0-preview1-34530</MicrosoftExtensionsHttpPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.0</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETCoreApp22PackageVersion>2.2.0-preview1-26618-02</MicrosoftNETCoreApp22PackageVersion>

--- a/src/Microsoft.AspNetCore.Proxy/Microsoft.AspNetCore.Proxy.csproj
+++ b/src/Microsoft.AspNetCore.Proxy/Microsoft.AspNetCore.Proxy.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="$(MicrosoftAspNetCoreWebSocketsPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsHttpPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Proxy/ProxyService.cs
+++ b/src/Microsoft.AspNetCore.Proxy/ProxyService.cs
@@ -9,7 +9,10 @@ namespace Microsoft.AspNetCore.Proxy
 {
     public class ProxyService
     {
-        public ProxyService(IOptions<SharedProxyOptions> options)
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly HttpClient _httpClient;
+
+        public ProxyService(IOptions<SharedProxyOptions> options, IHttpClientFactory httpClientFactory)
         {
             if (options == null)
             {
@@ -17,10 +20,17 @@ namespace Microsoft.AspNetCore.Proxy
             }
 
             Options = options.Value;
-            Client = new HttpClient(Options.MessageHandler ?? new HttpClientHandler { AllowAutoRedirect = false, UseCookies = false });
+            if (Options.MessageHandler != null)
+            {
+                _httpClient = new HttpClient(Options.MessageHandler);
+            }
+            else
+            {
+                _httpClientFactory = httpClientFactory;
+            }
         }
 
         public SharedProxyOptions Options { get; private set; }
-        internal HttpClient Client { get; private set; }
+        internal HttpClient Client => _httpClientFactory?.CreateClient() ?? _httpClient;
     }
 }

--- a/src/Microsoft.AspNetCore.Proxy/ProxyServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Proxy/ProxyServiceCollectionExtensions.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(services));
             }
 
+            services.AddHttpClient();
+
             return services.AddSingleton<ProxyService>();
         }
 
@@ -28,6 +30,8 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(configureOptions));
             }
+
+            services.AddHttpClient();
 
             services.Configure(configureOptions);
             return services.AddSingleton<ProxyService>();


### PR DESCRIPTION
Use `HttpClientFactory` when `MessageHandler` not specified

/cc @glennc 